### PR TITLE
layouts: properly deprecate .Site.Social usage

### DIFF
--- a/.changeset/brown-keys-wait.md
+++ b/.changeset/brown-keys-wait.md
@@ -1,0 +1,5 @@
+---
+"@thulite/seo": patch
+---
+
+Properly deprecate .Site.Social usage.

--- a/layouts/partials/seo/opengraph.html
+++ b/layouts/partials/seo/opengraph.html
@@ -41,11 +41,6 @@
   {{- if reflect.IsMap . }}
     {{- $facebookAdmin = .facebook_admin }}
   {{- end }}
-{{- else }}
-  {{- with site.Social.facebook_admin }}
-    {{- $facebookAdmin = . }}
-    {{- warnf "The social key in site configuration is deprecated. Use params.social.facebook_admin instead." }}
-  {{- end }}
 {{- end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}

--- a/layouts/partials/seo/twitter.html
+++ b/layouts/partials/seo/twitter.html
@@ -15,11 +15,6 @@
   {{- if reflect.IsMap . }}
     {{- $twitterSite = .twitter }}
   {{- end }}
-{{- else }}
-  {{- with site.Social.twitter }}
-    {{- $twitterSite = . }}
-    {{- warnf "The social key in site configuration is deprecated. Use params.social.twitter instead." }}
-  {{- end }}
 {{- end }}
 
 {{- with $twitterSite }}


### PR DESCRIPTION
## Summary

Hugo recently started throwing an error when accessing .Site.Social.
This has been deprecated since 0.124 and will be removed in 0.137.

## Motivation

This package's usage to throw its own deprecation warning makes builds
with a recent hugo version fail (so pretty much everyone's)---remove it.


Signed-off-by: Luca Zeuch <l-zeuch@email.de>

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test` (if relevant) (no such script, but `npm run format` passes.)
